### PR TITLE
Convert_id returned by endpoints from ObjectID to String

### DIFF
--- a/routes/auth/profileController.js
+++ b/routes/auth/profileController.js
@@ -575,6 +575,12 @@ function getDefaultAggregateOptions(req) {
         $unset: ['password'],
     });
 
+    aggregate_options.push({
+        $addFields: { '_id': {
+                '$toString': '$_id'
+            }},
+    })
+
     const aggregate = Profile.aggregate(aggregate_options);
 
     //Pagination


### PR DESCRIPTION
_id returned by /profiles/ endpoint was ObjectID, while _id returned by /profiles/public is String.
I've changed it so that both returned String.